### PR TITLE
Fix local dev install script on fresh machines

### DIFF
--- a/scripts/install-locally.sh
+++ b/scripts/install-locally.sh
@@ -14,6 +14,7 @@ fi
 if [ ! -f licenses.html ]; then
     bash pre-maturin-build.sh
 fi
+
 maturin build "${@:1}"
 
 

--- a/scripts/install-locally.sh
+++ b/scripts/install-locally.sh
@@ -10,6 +10,10 @@ if [ $# -eq 0 ]; then
 else
     echo "Creating a build with maturin build ${@:1}"
 fi
+
+if [ ! -f licenses.html ]; then
+    bash pre-maturin-build.sh
+fi
 maturin build "${@:1}"
 
 


### PR DESCRIPTION
Fixes install script for fresh installations.

```


🍹 Building a mixed python/rust project
🔗 Found bin bindings
📡 Using build options locked, bindings from pyproject.toml
💻 Using `MACOSX_DEPLOYMENT_TARGET=11.0` for aarch64-apple-darwin by default
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
💻 Using `MACOSX_DEPLOYMENT_TARGET=11.0` for aarch64-apple-darwin by default
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
💻 Using `MACOSX_DEPLOYMENT_TARGET=11.0` for aarch64-apple-darwin by default
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
💥 maturin failed
  Caused by: Failed to read /Users/aa/Projects/zuban/deploy/pypi/zuban/licenses.html
  Caused by: failed to open file `/Users/aa/Projects/zuban/deploy/pypi/zuban/licenses.html`: No such file or directory (os error 2)

```


- [x] I Artem Golubin own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
