### PR TITLE
Support python installations with a lib64 directory (Fedora / Redhat a like)

### DIFF
--- a/crates/zuban_python/src/sys_path.rs
+++ b/crates/zuban_python/src/sys_path.rs
@@ -294,21 +294,25 @@ pub(crate) fn typeshed_path_from_executable() -> Arc<NormalizedPath> {
             return p;
         }
     } else {
-        let lib_folder = env_folder.join("lib");
-        // The lib folder typically contains a Python specific folder called "python3.8" or
-        // python3.13", corresponding to the Python version. Here we try to find the package.
-        for folder in lib_folder.read_dir().unwrap_or_else(|err| {
-            panic!(
-                "The Python environment lib folder {lib_folder:?} should be readable ({err}).
-                    You might want to set ZUBAN_TYPESHED."
-            )
-        }) {
-            let folder = folder.unwrap_or_else(|err| {
-                panic!("The lib folder {lib_folder:?} should be readable ({err})")
-            });
-            let p = folder.path();
-            if let Some(found) = maybe_has_zuban(&p) {
-                return found;
+        // On Fedora / Redhat based systems with 64-bit architectures, Zuban is installed
+        // in the lib64 directory. We should look there as well.
+        let lib_folders = vec![env_folder.join("lib"), env_folder.join("lib64")];
+        for lib_folder in &lib_folders {
+            // The lib folder typically contains a Python specific folder called "python3.8" or
+            // python3.13", corresponding to the Python version. Here we try to find the package.
+            for folder in lib_folder.read_dir().unwrap_or_else(|err| {
+                panic!(
+                    "The Python environment lib folder {lib_folder:?} should be readable ({err}).
+                        You might want to set ZUBAN_TYPESHED."
+                )
+            }) {
+                let folder = folder.unwrap_or_else(|err| {
+                    panic!("The lib folder {lib_folder:?} should be readable ({err})")
+                });
+                let p = folder.path();
+                if let Some(found) = maybe_has_zuban(&p) {
+                    return found;
+                }
             }
         }
     }


### PR DESCRIPTION
When the typeshed folder is not found in the regular `lib/python-xxx/site-packages/zuban` folder,  Zuban panics with a "Did not find a typeshed folder in ..." message. 

On some systems (like Fedora, Rocky Linux or any Redhat derivative) 64-bit python packages with platform specific binaries are installed in a `lib64/python-xxx/site-packages` folder.

This PR implements to look for the typeshed definitions in `lib64/....`  in case Zuban is not installed in `lib/python-xxx/site-packages/`

Fixes #142 and #146

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [X] I (Martijn Jacobs) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
