### PR TITLE
Don't complete inside strings

### DIFF
--- a/crates/parsa_python_cst/src/completion.rs
+++ b/crates/parsa_python_cst/src/completion.rs
@@ -2,7 +2,8 @@ use parsa_python::{
     CodeIndex,
     NonterminalType::*,
     PyNode,
-    PyNodeType::{ErrorNonterminal, Nonterminal},
+    PyNodeType::{self, ErrorNonterminal, Nonterminal},
+    TerminalType,
 };
 
 use crate::{
@@ -44,6 +45,11 @@ impl Tree {
             },
             position,
         );
+
+        if leaf.is_type(PyNodeType::Terminal(TerminalType::String)) {
+            return (scope, CompletionNode::InsideString, rest);
+        }
+
         if let Some(previous) = leaf.previous_leaf() {
             match previous.as_code() {
                 "." => {
@@ -363,6 +369,7 @@ pub enum CompletionNode<'db> {
     NecessaryKeyword(&'static str),
     AfterDefKeyword,
     AfterClassKeyword,
+    InsideString,
     Global {
         context: Option<CompletionContext<'db>>,
     },

--- a/crates/zuban_python/src/completion.rs
+++ b/crates/zuban_python/src/completion.rs
@@ -228,6 +228,7 @@ impl<'db, C: for<'a> Fn(Range, &dyn Completion) -> Option<T>, T> CompletionResol
             }
             CompletionNode::AfterDefKeyword => (),
             CompletionNode::AfterClassKeyword => (),
+            CompletionNode::InsideString => (),
         }
     }
 

--- a/crates/zuban_python/tests/blackbox/python_files/completions.py
+++ b/crates/zuban_python/tests/blackbox/python_files/completions.py
@@ -144,3 +144,10 @@ def primary_target_completions():
     import_tree.mod1. = 5
     #? 4 --contains-subset ["help", "str"]
     .mod1.a = 6
+
+def no_completion_inside_string_test():
+    some_variable = 1
+    #? 14 --no-name-filter []
+    " some_var "
+    #? 16 --no-name-filter []
+    """ some_var """


### PR DESCRIPTION
A lazy attempt to fix https://github.com/zubanls/zuban/issues/225

It's in line with other tools, as neither `ty` nor `pyright` complete symbols inside strings. The difference is that `zuban` will still complete in an unclosed string (eg. `some_symbol = 1 ; a = "some_sym`), but at least in this case the completion is flawless without catastrophic effects like in the linked github issue. I tried to support unclosed strings too, but either I don't know how, or zuban's partial parser can't handle this case.

I added `--no-name-filter` flag to test cases, as the symbol under cursor was detected as `""" some_var` instead of `some_var`.  I might have tried to the root cause of this issue, but "name under cursor" filtering is used in tests only, as far as I can tell, so maybe it's not that big of a deal.

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [x] I Marcin Bachry own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
