### PR TITLE
fix: use platform-appropriate path list separator when parsing environment variables

### DIFF
--- a/crates/config/src/venv.rs
+++ b/crates/config/src/venv.rs
@@ -17,9 +17,10 @@ impl Settings {
     ) {
         let mut add_to_mypy_path = |lookup: EnvResult| {
             if let Ok(found_path) = lookup {
-                self.mypy_path.extend(found_path.split(PATH_SEPARATOR).map(|p| {
-                    vfs_handler.normalize_rc_path(vfs_handler.absolute_path(base_directory, p))
-                }))
+                self.mypy_path
+                    .extend(found_path.split(PATH_SEPARATOR).map(|p| {
+                        vfs_handler.normalize_rc_path(vfs_handler.absolute_path(base_directory, p))
+                    }))
             }
         };
         add_to_mypy_path(lookup_env_var("PYTHONPATH"));


### PR DESCRIPTION

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [x] I (Ekopalypse) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
