### PR TITLE
Extend publish CI to publish releases on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ concurrency:
 
 permissions:
     id-token: write
-    contents: read
+    contents: write
 
 on:
   push:
@@ -41,3 +41,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
             packages-dir: "wheels/"
+      - name: Publish GitHub Release
+        env:
+          TITLE: "${{ github.ref_name }}"
+          BODY: "Full changelog available [here](https://docs.zubanls.com/en/latest/changelog.html)"
+          COMMIT: "${{ github.sha }}"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "$BODY" > $RUNNER_TEMP/notes.txt
+          gh release create "${{ github.ref_name }}" --target "$COMMIT" --title "$TITLE" --notes-file "$RUNNER_TEMP/notes.txt"


### PR DESCRIPTION
<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

As discussed in #345, this extends the release workflow to also publish releases on GitHub so users (like me) can get notified when a new release is made. I've added a link to the changelog on Zuban's official website so we can easily see what got changed.

- [x] I (Mauricio A. Rovira Galvez) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
