### PR TITLE
fix: derive python version from python_executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "clap",
  "regex",
  "rust-ini",
+ "tempfile",
  "toml_edit",
  "tracing",
  "vfs",
@@ -308,7 +309,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -568,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +700,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1253,12 +1272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1296,7 +1321,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.16",
 ]
@@ -1594,6 +1619,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1899,6 +1937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2222,12 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tracing-appender = "*"
 
 # Dev dependencies
 insta = "*"
+tempfile = "*"
 
 [workspace.metadata.release]
 pre-release-hook = [

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,3 +19,7 @@ rust-ini = { version = "0.21.0", features = ["inline-comment"], git = "https://g
 regex.workspace = true
 tracing.workspace = true
 toml_edit.workspace = true
+
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -11,6 +11,7 @@ use toml_edit::{DocumentMut, Item, Table, Value};
 use vfs::{AbsPath, Directory, GlobAbsPath, LocalFS, NormalizedPath, VfsHandler};
 
 pub use searcher::{find_cli_config, find_workspace_config};
+pub use venv::extract_version_from_pyvenv_cfg;
 
 type ConfigResult = anyhow::Result<()>;
 
@@ -145,6 +146,14 @@ impl Settings {
             bail!(ERR)
         }
         self.environment = environment;
+
+        if self.python_version.is_none() {
+            if let Some(env_path) = &self.environment {
+                if let Some(version) = extract_version_from_pyvenv_cfg(env_path.as_ref()) {
+                    self.python_version = Some(version);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/config/src/venv.rs
+++ b/crates/config/src/venv.rs
@@ -73,6 +73,53 @@ impl Settings {
     }
 }
 
+pub fn extract_version_from_pyvenv_cfg(env_path: &NormalizedPath) -> Option<PythonVersion> {
+    let pyvenv_cfg_path = env_path.as_ref().join("pyvenv.cfg");
+    let code = match std::fs::read_to_string(&pyvenv_cfg_path) {
+        Ok(string) => string,
+        Err(err) => {
+            // pyvenv.cfg doesn't exist - this is normal for system Python installations
+            tracing::debug!("Error while reading {pyvenv_cfg_path:?}: {err}");
+            return None;
+        }
+    };
+
+    match parse_python_ini(&code) {
+        Ok(ini) => {
+            // Try "version" field first (stdlib venv format)
+            if let Some(version_str) = ini.get_from(None::<String>, "version") {
+                match PythonVersion::from_str(version_str) {
+                    Ok(v) => return Some(v),
+                    Err(err) => {
+                        tracing::warn!(
+                            "Parsing Python version in {pyvenv_cfg_path:?} failed: {err}"
+                        );
+                        return None;
+                    }
+                }
+            }
+            // Fallback to "version_info" field (uv format)
+            if let Some(version_str) = ini.get_from(None::<String>, "version_info") {
+                match PythonVersion::from_str(version_str) {
+                    Ok(v) => return Some(v),
+                    Err(err) => {
+                        tracing::warn!(
+                            "Parsing Python version in {pyvenv_cfg_path:?} failed: {err}"
+                        );
+                        return None;
+                    }
+                }
+            }
+            tracing::warn!("Found {pyvenv_cfg_path:?}, but it has no \"version\" field");
+            None
+        }
+        Err(err) => {
+            tracing::warn!("Parsing Python version in {pyvenv_cfg_path:?} failed: {err}");
+            None
+        }
+    }
+}
+
 fn try_to_find_env_in_dir(
     environment: &mut Option<Arc<NormalizedPath>>,
     py_version: &mut Option<PythonVersion>,
@@ -115,11 +162,11 @@ fn try_to_find_env_in_dir(
     });
     for entry in dir_entries {
         let venv_path = entry.path();
-        let pyvenv_cfg_path = venv_path.join("pyvenv.cfg");
         let Some(venv_path_str) = venv_path.to_str() else {
             tracing::debug!("{venv_path:?} must be utf8 if wants to be a venv -> ignored");
             continue;
         };
+        let pyvenv_cfg_path = venv_path.join("pyvenv.cfg");
         let code = match std::fs::read_to_string(&pyvenv_cfg_path) {
             Ok(string) => string,
             Err(err) => {
@@ -127,28 +174,166 @@ fn try_to_find_env_in_dir(
                 continue;
             }
         };
-        if let Ok(ini) = parse_python_ini(&code) {
-            // TODO use include-system-site-packages = false
-            *environment =
-                Some(vfs_handler.normalize_rc_path(vfs_handler.unchecked_abs_path(venv_path_str)));
 
-            if py_version.is_none() {
-                if let Some(version_str) = ini.get_from(None::<String>, "version") {
-                    match PythonVersion::from_str(version_str) {
-                        Ok(v) => *py_version = Some(v),
-                        Err(err) => {
-                            tracing::warn!(
-                                "Parsing Python version in {pyvenv_cfg_path:?} failed: {err}"
-                            );
-                        }
-                    }
-                } else {
-                    tracing::warn!("Found {pyvenv_cfg_path:?}, but it has no \"version\" field");
-                }
-            }
-            tracing::info!("Found venv in {venv_path_str:?}");
-            return true;
+        if parse_python_ini(&code).is_err() {
+            continue;
         }
+
+        // TODO use include-system-site-packages = false
+        *environment =
+            Some(vfs_handler.normalize_rc_path(vfs_handler.unchecked_abs_path(venv_path_str)));
+
+        if py_version.is_none() {
+            let env_path = environment.as_ref().unwrap();
+            if let Some(version) = extract_version_from_pyvenv_cfg(env_path.as_ref()) {
+                *py_version = Some(version);
+            }
+        }
+
+        tracing::info!("Found venv in {venv_path_str:?}");
+        return true;
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use vfs::LocalFS;
+
+    #[test]
+    fn test_extract_version_from_pyvenv_cfg_version_field() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pyvenv_cfg_path = temp_dir.path().join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "version = 3.12").unwrap();
+
+        let handler = LocalFS::without_watcher();
+        let env_path = handler.unchecked_normalized_path(
+            handler.unchecked_abs_path(temp_dir.path().to_str().unwrap()),
+        );
+        let version = extract_version_from_pyvenv_cfg(&env_path).unwrap();
+        assert_eq!(version.major, 3);
+        assert_eq!(version.minor, 12);
+    }
+
+    #[test]
+    fn test_extract_version_from_pyvenv_cfg_version_info_field() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pyvenv_cfg_path = temp_dir.path().join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "version_info = 3.11.5").unwrap();
+
+        let handler = LocalFS::without_watcher();
+        let env_path = handler.unchecked_normalized_path(
+            handler.unchecked_abs_path(temp_dir.path().to_str().unwrap()),
+        );
+        let version = extract_version_from_pyvenv_cfg(&env_path).unwrap();
+        assert_eq!(version.major, 3);
+        assert_eq!(version.minor, 11);
+    }
+
+    #[test]
+    fn test_extract_version_from_pyvenv_cfg_version_takes_priority() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pyvenv_cfg_path = temp_dir.path().join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "version = 3.12").unwrap();
+        writeln!(file, "version_info = 3.11.5").unwrap();
+
+        let handler = LocalFS::without_watcher();
+        let env_path = handler.unchecked_normalized_path(
+            handler.unchecked_abs_path(temp_dir.path().to_str().unwrap()),
+        );
+        let version = extract_version_from_pyvenv_cfg(&env_path).unwrap();
+
+        assert_eq!(version.major, 3);
+        assert_eq!(version.minor, 12);
+    }
+
+    #[test]
+    fn test_extract_version_from_pyvenv_cfg_missing_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let handler = LocalFS::without_watcher();
+        let env_path = handler.unchecked_normalized_path(
+            handler.unchecked_abs_path(temp_dir.path().to_str().unwrap()),
+        );
+        let version = extract_version_from_pyvenv_cfg(&env_path);
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_from_pyvenv_cfg_missing_version_fields() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pyvenv_cfg_path = temp_dir.path().join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "home = /usr/bin/python3").unwrap();
+        writeln!(file, "include-system-site-packages = false").unwrap();
+
+        let handler = LocalFS::without_watcher();
+        let env_path = handler.unchecked_normalized_path(
+            handler.unchecked_abs_path(temp_dir.path().to_str().unwrap()),
+        );
+        let version = extract_version_from_pyvenv_cfg(&env_path);
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_apply_python_executable_extracts_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let venv_path = temp_dir.path().join("test_venv");
+        std::fs::create_dir(&venv_path).unwrap();
+        let bin_path = venv_path.join("bin");
+        std::fs::create_dir(&bin_path).unwrap();
+        let python_path = bin_path.join("python");
+        std::fs::write(&python_path, "").unwrap();
+
+        let pyvenv_cfg_path = venv_path.join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "version = 3.12").unwrap();
+
+        let mut settings = Settings::default();
+        let handler = LocalFS::without_watcher();
+        let project_dir = handler.unchecked_abs_path(temp_dir.path().to_str().unwrap());
+
+        settings
+            .apply_python_executable(&handler, &project_dir, None, python_path.to_str().unwrap())
+            .unwrap();
+
+        let version = settings.python_version.unwrap();
+        assert_eq!(version.major, 3);
+        assert_eq!(version.minor, 12);
+    }
+
+    #[test]
+    fn test_apply_python_executable_respects_explicit_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let venv_path = temp_dir.path().join("test_venv");
+        std::fs::create_dir(&venv_path).unwrap();
+        let bin_path = venv_path.join("bin");
+        std::fs::create_dir(&bin_path).unwrap();
+        let python_path = bin_path.join("python");
+        std::fs::write(&python_path, "").unwrap();
+
+        let pyvenv_cfg_path = venv_path.join("pyvenv.cfg");
+        let mut file = std::fs::File::create(&pyvenv_cfg_path).unwrap();
+        writeln!(file, "version = 3.12").unwrap();
+
+        let mut settings = Settings::default();
+        settings.python_version = Some(PythonVersion::new(3, 10));
+
+        let handler = LocalFS::without_watcher();
+        let project_dir = handler.unchecked_abs_path(temp_dir.path().to_str().unwrap());
+
+        settings
+            .apply_python_executable(&handler, &project_dir, None, python_path.to_str().unwrap())
+            .unwrap();
+
+        let version = settings.python_version.unwrap();
+        assert_eq!(version.major, 3);
+        assert_eq!(version.minor, 10);
+    }
 }


### PR DESCRIPTION
Extract Python version from pyvenv.cfg when python_executable is a part of virtual environment.

Also handle pyvenv.cfg generated by uv.

Issue: #355

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [X ] I (Aleksander Trofimowicz) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
