### PR TITLE
Fix panic on non-char-boundary byte index in PositionInfos::line_part

### DIFF
--- a/crates/zuban_python/src/lines.rs
+++ b/crates/zuban_python/src/lines.rs
@@ -166,8 +166,16 @@ impl NewlineIndices {
         code: &'code str,
         byte_position: CodeIndex,
     ) -> PositionInfos<'code> {
+        // Byte positions from forward-reference sub-files may land inside multi-byte
+        // UTF-8 characters because Python string unescaping can change byte lengths
+        // (e.g. `\xa7` → `§`). Clamp to the nearest valid char boundary to avoid
+        // panicking when slicing the code string.
+        let mut byte_position = (byte_position as usize).min(code.len());
+        while byte_position > 0 && !code.is_char_boundary(byte_position) {
+            byte_position -= 1;
+        }
         let lines = self.lines(code);
-        let line = lines.partition_point(|&l| l <= byte_position);
+        let line = lines.partition_point(|&l| l <= byte_position as CodeIndex);
         PositionInfos {
             line,
             code,
@@ -175,7 +183,7 @@ impl NewlineIndices {
                 .checked_sub(1)
                 .map(|line| lines[line] as usize)
                 .unwrap_or(0),
-            byte_position: byte_position as usize,
+            byte_position,
         }
     }
 
@@ -390,5 +398,35 @@ mod tests {
         assert_eq!(check(c2, 4..4), 4..5);
         assert_eq!(check(c2, 1..5), 0..5);
         assert_eq!(check(c2, 1..8), 0..5);
+    }
+
+    #[test]
+    fn test_position_infos_non_char_boundary() {
+        // Regression test for GH #362: position_infos should not panic when
+        // byte_position falls inside a multi-byte UTF-8 character.
+        let indices = NewlineIndices::new();
+        let code = "a:'''\n'\\xa7'\n'Й\\r'\n'''";
+        // 'Й' is at bytes 14..16 (two-byte UTF-8: 0xD0 0x99).
+        // Byte 15 is inside the character and is NOT a char boundary.
+        assert!(!code.is_char_boundary(15));
+
+        // position_infos must not panic; it should clamp to byte 14.
+        let infos = indices.position_infos(code, 15);
+        assert_eq!(infos.byte_position, 14);
+        // The clamped position is on line 2 (zero-based), starting at byte 13.
+        assert_eq!(infos.line_zero_based(), 2);
+        assert_eq!(infos.line_one_based(), 3);
+        // Column methods must also not panic.
+        assert_eq!(infos.utf8_bytes_column(), 1);
+        assert_eq!(infos.code_points_column(), 1);
+    }
+
+    #[test]
+    fn test_position_infos_beyond_code_length() {
+        // position_infos should handle byte_position beyond code length.
+        let indices = NewlineIndices::new();
+        let code = "ab";
+        let infos = indices.position_infos(code, 100);
+        assert_eq!(infos.byte_position, 2);
     }
 }

--- a/crates/zuban_python/tests/mypylike/tests/flags.test
+++ b/crates/zuban_python/tests/mypylike/tests/flags.test
@@ -774,6 +774,18 @@ class P(Protocol):
 [out]
 __main__:3:1:3:4: error: "int" not callable
 
+[case show_error_end_multibyte_annotation_no_crash]
+# flags: --show-error-end
+# Regression test for GH #362: --show-error-end must not panic on
+# multi-byte UTF-8 characters in string annotations with escape sequences.
+a:'''
+'\xa7'
+'Й\r'
+'''
+[out]
+__main__:5:1:5:5: error: Invalid syntax
+__main__:6:2:6:3: error: Invalid syntax
+
 [case allow_incomplete_generics]
 # flags: --allow-incomplete-generics
 from typing import Generic, TypeVar, assert_type, Any

--- a/crates/zuban_python/tests/mypylike/tests/flags.test
+++ b/crates/zuban_python/tests/mypylike/tests/flags.test
@@ -786,6 +786,10 @@ a:'''
 __main__:5:1:5:5: error: Invalid syntax
 __main__:6:2:6:3: error: Invalid syntax
 
+[out.windows]
+__main__:4:7:5:4: error: Invalid syntax
+__main__:6:1:6:2: error: Invalid syntax
+
 [case allow_incomplete_generics]
 # flags: --allow-incomplete-generics
 from typing import Generic, TypeVar, assert_type, Any


### PR DESCRIPTION
Hi, I spun up copilot to have a crack at fixing an issue, feedback welcome.
New tests are included; tests pass.

Closes #362

---

`zuban check --show-error-end` panics on string annotations containing escape sequences alongside multi-byte UTF-8 characters:

```python
a:'''
'\xa7'
'Й\r'
'''
```

```
thread 'main' panicked at crates/zuban_python/src/lines.rs:263:19:
byte index 15 is not a char boundary; it is inside 'Й' (bytes 14..16)
```

**Root cause:** Forward-reference sub-files map positions back to the parent file via `offset + byte`, but Python string unescaping changes byte lengths (`\xa7` 4→2 bytes, `\r` 2→1 byte). The resulting offset can land inside a multi-byte character. `--show-error-end` is the trigger because it's the only path that calls `end_position().code_points_column()`, which hits `line_part()` → `&code[line_offset..byte_position]`.

**Fix:** Clamp `byte_position` to the nearest preceding char boundary in `position_infos()`. This is consistent with the existing acknowledged imprecision for escaped annotations (see `type_computation/mod.rs:430`). Normal code paths are unaffected — the clamping loop is a no-op when the position is already valid.

- **`lines.rs`**: `position_infos()` now clamps + boundary-adjusts `byte_position` before use
- **`lines.rs`**: Unit tests for non-char-boundary and beyond-length inputs
- **`flags.test`**: Integration test with the exact reproducer from the issue