### PR TITLE
Update CI actions to latest versions to fix Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/debug_wheels.yml
+++ b/.github/workflows/debug_wheels.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: ${{ github.workspace }}
     steps:
       - name: "Download Wheels from GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Download Wheels from GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.debug_ssh_session }}
@@ -48,11 +48,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       - name: "Run tests"
         run: |
             rustup show -v

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,11 +100,11 @@ jobs:
             install_cmd: apk add bash
     runs-on: ${{ matrix.t.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           # The target is needed, because there were issues when reusing
           # caches, probably related to cross compiling.
@@ -121,7 +121,7 @@ jobs:
           args: --release --locked --out dist --ignore-rust-version
 
       - name: "Setup Python ${{ inputs.python_version }} (native)"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: matrix.t.test == 'native'
         with:
           python-version: ${{ inputs.python_version }}
@@ -147,7 +147,7 @@ jobs:
             "
 
       - name: "Upload wheel as a GitHub Artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.t.os }}-${{ matrix.t.target }}
           path: "${{ env.DEPLOY_DIR }}/dist"


### PR DESCRIPTION
GitHub Actions workflow summaries show `Node.js 20 actions are deprecated` warnings. Updates all actions to their latest versions using Node 22, preserving the existing pinning convention (moving tags stay as moving tags, commit hashes stay as commit hashes).

- `actions/checkout`: v4 → v6
- `Swatinem/rust-cache`: `f0deed1e` (v2.7.7) → `c1937114` (v2.9.1)
- `actions/setup-python`: v5 → v6
- `actions/upload-artifact`: v4 → v7
- `actions/download-artifact`: v4 → v8

No update needed for `mxschmitt/action-tmate@v3`, `PyO3/maturin-action@v1`, `pypa/gh-action-pypi-publish@release/v1` — already at latest major.
