### PR TITLE
Add support for Django ForeignKey related_name reverse relations

### DIFF
--- a/crates/vfs/src/local_fs.rs
+++ b/crates/vfs/src/local_fs.rs
@@ -90,9 +90,10 @@ impl<T: Fn(PathWithScheme) + Sync + Send> VfsHandler for LocalFS<T> {
                                         continue;
                                     }
                                 }
-                            } else {
-                                debug_assert!(file_type.is_file());
+                            } else if file_type.is_file() {
                                 ResolvedFileType::File
+                            } else {
+                                continue;
                             };
                             let n: Arc<str> = name.into();
                             if &*n == ".gitignore" && matches!(new, ResolvedFileType::File) {
@@ -155,10 +156,11 @@ impl<T: Fn(PathWithScheme) + Sync + Send> VfsHandler for LocalFS<T> {
                     return None;
                 }
             }
-        } else {
-            debug_assert!(metadata.is_file());
+        } else if metadata.is_file() {
             self.watch(path);
             ResolvedFileType::File
+        } else {
+            return None;
         };
         resolved.into_dir_entry(workspaces, self, parent, replace_name.into())
     }
@@ -350,9 +352,10 @@ impl<T: Fn(PathWithScheme) + Sync + Send> LocalFS<T> {
             Ok(ResolvedFileType::Directory)
         } else if file_type.is_symlink() {
             self.follow_symlink_internal(origin_path, &target_path)
-        } else {
-            debug_assert!(file_type.is_file());
+        } else if file_type.is_file() {
             Ok(ResolvedFileType::File)
+        } else {
+            Err(format!("Unsupported file type at {target_path:?}"))
         }
     }
 }

--- a/crates/zuban_python/src/completion.rs
+++ b/crates/zuban_python/src/completion.rs
@@ -665,6 +665,41 @@ impl<'db, C: Fn(Range, &dyn Completion) -> Option<T>, T> CompletionResolver<'db,
                 }
             }
         }
+        // Add related_name reverse FK completions for Django models.
+        // Only on user-defined models (not Django stubs), since related_names come from user code.
+        if is_instance && is_django_base && !file.is_from_django(self.infos.db) {
+            for (_, &name_index) in file.symbol_table.iter() {
+                let Some(class_def) =
+                    NodeRef::new(file, name_index).maybe_name_of_class()
+                else {
+                    continue;
+                };
+                let class_node_ref = ClassNodeRef::new(file, class_def.index());
+                let other_class = Class::with_undefined_generics(class_node_ref);
+                if other_class.has_django_stubs_base_class(self.infos.db) {
+                    for (field_name, _) in other_class.class_storage.class_symbol_table.iter() {
+                        // Use get_django_foreign_key_related_name (CST-only, no type inference)
+                        // to avoid generating delayed diagnostics as a side effect.
+                        if let Some(rn) = other_class
+                            .get_django_foreign_key_related_name(self.infos.db, field_name)
+                            && rn != "+"
+                        {
+                            if !self.maybe_add_cow(Cow::Owned(rn.clone())) {
+                                continue;
+                            }
+                            if let Some(result) =
+                                (self.on_result)(self.replace_range, &FixedStringField(rn))
+                            {
+                                self.items.push((
+                                    CompletionSortPriority::new_symbol(field_name),
+                                    result,
+                                ))
+                            }
+                        }
+                    }
+                }
+            }
+        }
         if is_instance {
             for (symbol, &node_index) in storage.self_symbol_table.iter() {
                 if !self.maybe_add(symbol) || is_private(symbol) || should_ignore(symbol) {

--- a/crates/zuban_python/src/file/flow_analysis.rs
+++ b/crates/zuban_python/src/file/flow_analysis.rs
@@ -492,12 +492,19 @@ impl FlowAnalysis {
             result: callable(),
             unfinished_partials: self.partials_in_module.take(),
         };
+        // Attribute lookup on newly-typed class values (e.g. RelatedManager[Book]) can trigger
+        // ensure_calculated_diagnostics_for_class → with_new_empty_and_delay_further, which
+        // legitimately adds delayed diagnostics. Propagate them to the outer context rather than
+        // asserting they're empty, so the outer with_new_empty_for_file can process them.
+        let inner_delayed = self.delayed_diagnostics.take();
         self.debug_assert_is_empty();
 
         *self.frames.borrow_mut() = old_frames;
         *self.try_frames.borrow_mut() = try_frames;
         *self.loop_details.borrow_mut() = loop_details;
-        *self.delayed_diagnostics.borrow_mut() = delayed;
+        let mut merged_delayed = delayed;
+        merged_delayed.extend(inner_delayed);
+        *self.delayed_diagnostics.borrow_mut() = merged_delayed;
         *self.partials_in_module.borrow_mut() = partials;
         self.in_type_checking_only_block
             .set(in_type_checking_only_block);

--- a/crates/zuban_python/src/type_helpers/class.rs
+++ b/crates/zuban_python/src/type_helpers/class.rs
@@ -5,7 +5,16 @@ use std::{
     sync::Arc,
 };
 
-use parsa_python_cst::{Assignment, AssignmentContent, AtomContent, ClassDef, Name, TypeLike};
+thread_local! {
+    // Prevents re-entrant calls to find_django_related_name_source_class, which can happen when
+    // type inference triggered inside loops back into attribute lookup.
+    static IS_DJANGO_RELATED_NAME_RUNNING: Cell<bool> = const { Cell::new(false) };
+}
+
+use parsa_python_cst::{
+    Argument, ArgumentsDetails, Assignment, AssignmentContent, AtomContent, ClassDef,
+    ExpressionContent, ExpressionPart, Name, PrimaryContent, PrimaryOrAtom, TypeLike,
+};
 
 use super::{Callable, Instance, InstanceLookupOptions, LookupDetails, overload::OverloadResult};
 use crate::{
@@ -17,8 +26,8 @@ use crate::{
     debug,
     diagnostics::IssueKind,
     file::{
-        ClassInitializer, ClassNodeRef, FLOW_ANALYSIS, FuncNodeRef, StarImportError,
-        TypeVarCallbackReturn, use_cached_return_annotation_type,
+        CLASS_TO_CLASS_INFO_DIFFERENCE, ClassInitializer, ClassNodeRef, FLOW_ANALYSIS, FuncNodeRef,
+        StarImportError, TypeVarCallbackReturn, use_cached_return_annotation_type,
     },
     format_data::FormatData,
     getitem::SliceType,
@@ -313,7 +322,8 @@ impl<'db: 'a, 'a> Class<'a> {
     }
 
     pub fn is_protocol(&self, db: &Database) -> bool {
-        self.use_cached_class_infos(db).kind == ClassKind::Protocol
+        self.maybe_cached_class_infos(db)
+            .is_some_and(|ci| ci.kind == ClassKind::Protocol)
     }
 
     pub fn check_protocol_match(
@@ -2219,6 +2229,151 @@ impl<'db: 'a, 'a> Class<'a> {
                         && cls.file.name(db) == "fields"
                 })
             })
+    }
+
+    pub(crate) fn get_django_foreign_key_related_name(
+        &self,
+        db: &Database,
+        field_name: &str,
+    ) -> Option<String> {
+        debug_assert!(self.has_django_stubs_base_class(db));
+        let name_index = self.class_storage.class_symbol_table.lookup_symbol(field_name)?;
+        let name = NodeRef::new(self.file, name_index).expect_name();
+        let assignment = name.maybe_assignment_definition_name()?;
+        let right_side = match assignment.unpack() {
+            AssignmentContent::Normal(_, rhs) => rhs,
+            AssignmentContent::WithAnnotation(_, _, Some(rhs)) => rhs,
+            _ => return None,
+        };
+        let expr = right_side.maybe_simple_expression()?;
+        if let ExpressionContent::ExpressionPart(ExpressionPart::Primary(p)) = expr.unpack()
+            && let PrimaryContent::Execution(ArgumentsDetails::Node(args)) = p.second()
+        {
+            for arg in args.iter() {
+                if let Argument::Keyword(kwarg) = arg {
+                    let (kw_name, kw_value) = kwarg.unpack();
+                    if kw_name.as_code() == "related_name" {
+                        if let Some(str_lit) = kw_value.maybe_single_string_literal() {
+                            return Some(str_lit.content().to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the PointLink of the class (e.g. `Book`) that has a ForeignKey with
+    /// `related_name=name` pointing at `self` (e.g. `Author`).
+    pub(crate) fn find_django_related_name_source_class(
+        &self,
+        db: &Database,
+        name: &str,
+    ) -> Option<PointLink> {
+        if !self.has_django_stubs_base_class(db) {
+            return None;
+        }
+        // Guard against re-entrant calls: attribute lookup inside this method can loop back.
+        let already_running = IS_DJANGO_RELATED_NAME_RUNNING.with(|cell| cell.replace(true));
+        if already_running {
+            return None;
+        }
+        let result = self.find_django_related_name_source_class_inner(db, name);
+        IS_DJANGO_RELATED_NAME_RUNNING.with(|cell| cell.set(false));
+        result
+    }
+
+    fn find_django_related_name_source_class_inner(
+        &self,
+        db: &Database,
+        name: &str,
+    ) -> Option<PointLink> {
+        // Iterate file-level symbols to find class definitions with FK fields pointing back.
+        // Use only CST-level checks (no type inference) to avoid triggering side effects
+        // such as delayed diagnostics or recursive attribute lookups.
+        for (_, &name_index) in self.file.symbol_table.iter() {
+            let Some(class_def) = NodeRef::new(self.file, name_index).maybe_name_of_class() else {
+                continue;
+            };
+            let class_node_ref = ClassNodeRef::new(self.file, class_def.index());
+            // Only proceed if class infos have been computed (check avoids needing db lifetime).
+            let class_info_calculated = self
+                .file
+                .points
+                .get(class_def.index() + CLASS_TO_CLASS_INFO_DIFFERENCE as u32)
+                .calculated();
+            if !class_info_calculated {
+                continue;
+            }
+            let other_class = Class::with_undefined_generics(class_node_ref);
+            if !other_class.has_django_stubs_base_class(db) {
+                continue;
+            }
+            // Default reverse accessor: <lowercase_classname>_set
+            let default_accessor = format!("{}_set", other_class.name().to_lowercase());
+            for (field_name, _) in other_class.class_storage.class_symbol_table.iter() {
+                match other_class
+                    .get_django_foreign_key_related_name(db, field_name)
+                    .as_deref()
+                {
+                    Some("+") => {
+                        // related_name='+' disables the reverse accessor for this FK.
+                    }
+                    Some(explicit_rn) => {
+                        // Explicit related_name: match both it and the default _set.
+                        if explicit_rn == name || default_accessor == name {
+                            return Some(other_class.node_ref.as_link());
+                        }
+                    }
+                    None => {
+                        // No explicit related_name: use default _set if this is a FK-like field.
+                        if default_accessor == name
+                            && other_class.is_fk_like_field_cst(field_name)
+                        {
+                            return Some(other_class.node_ref.as_link());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// CST-level check: is `field_name`'s assignment a ForeignKey/OneToOneField/ManyToManyField call?
+    fn is_fk_like_field_cst(&self, field_name: &str) -> bool {
+        let Some(name_index) = self.class_storage.class_symbol_table.lookup_symbol(field_name)
+        else {
+            return false;
+        };
+        let name_node = NodeRef::new(self.file, name_index).expect_name();
+        let Some(assignment) = name_node.maybe_assignment_definition_name() else {
+            return false;
+        };
+        let right_side = match assignment.unpack() {
+            AssignmentContent::Normal(_, rhs) => rhs,
+            AssignmentContent::WithAnnotation(_, _, Some(rhs)) => rhs,
+            _ => return false,
+        };
+        let Some(expr) = right_side.maybe_simple_expression() else {
+            return false;
+        };
+        let ExpressionContent::ExpressionPart(ExpressionPart::Primary(p)) = expr.unpack() else {
+            return false;
+        };
+        if !matches!(p.second(), PrimaryContent::Execution(_)) {
+            return false;
+        }
+        let call_name = match p.first() {
+            PrimaryOrAtom::Atom(a) => match a.unpack() {
+                AtomContent::Name(n) => n.as_code(),
+                _ => return false,
+            },
+            PrimaryOrAtom::Primary(inner) => match inner.second() {
+                PrimaryContent::Attribute(n) => n.as_code(),
+                _ => return false,
+            },
+        };
+        matches!(call_name, "ForeignKey" | "OneToOneField" | "ManyToManyField")
     }
 }
 

--- a/crates/zuban_python/src/type_helpers/instance.rs
+++ b/crates/zuban_python/src/type_helpers/instance.rs
@@ -2,14 +2,18 @@ use std::{borrow::Cow, cell::Cell, sync::Arc};
 
 use parsa_python_cst::Name;
 
-use super::{Class, ClassLookupOptions, FirstParamKind, Function, MroIterator, class::TypeOrClass};
+use super::{
+    Class, ClassLookupOptions, FirstParamKind, Function, MroIterator, cache_class_name,
+    class::TypeOrClass,
+};
 use crate::{
     arguments::{Args, CombinedArgs, InferredArg, KnownArgs, KnownArgsWithCustomAddIssue},
     database::{ComplexPoint, Database, PointLink, Specific},
     debug,
     diagnostics::IssueKind,
-    file::{ORDERING_METHODS, on_argument_type_error},
+    file::{ClassInitializer, ORDERING_METHODS, PythonFile, on_argument_type_error},
     getitem::SliceType,
+    imports::{ImportResult, import_module_by_strings},
     inference_state::InferenceState,
     inferred::{
         ApplyClassDescriptorsOrigin, AttributeKind, Inferred, MroIndex, add_attribute_error,
@@ -18,10 +22,58 @@ use crate::{
     node_ref::NodeRef,
     result_context::ResultContext,
     type_::{
-        AnyCause, CallableLike, CallableParams, FunctionKind, IterInfos, LookupResult,
-        PropertySetterType, Type, TypeVarKind,
+        AnyCause, CallableLike, CallableParams, ClassGenerics, FunctionKind, GenericItem,
+        GenericsList, IterInfos, LookupResult, PropertySetterType, Type, TypeVarKind,
     },
 };
+
+/// Builds a `LookupResult` for a Django reverse FK `related_name` accessor.
+/// Returns `RelatedManager[source_class]` when the `RelatedManager` class can be found in the
+/// django stubs, otherwise falls back to `Any`.
+fn build_related_manager_lookup(
+    db: &Database,
+    from_file: &PythonFile,
+    source_class_link: PointLink,
+) -> LookupResult {
+    let manager_link = find_related_manager_link(db, from_file);
+    let source_type = Type::new_class(source_class_link, ClassGenerics::new_none());
+    match manager_link {
+        Some(link) => {
+            let manager_type = Type::new_class(
+                link,
+                ClassGenerics::List(GenericsList::new_generics(Arc::new([
+                    GenericItem::TypeArg(source_type),
+                ]))),
+            );
+            LookupResult::UnknownName(Inferred::from_type(manager_type))
+        }
+        None => LookupResult::any(AnyCause::Todo),
+    }
+}
+
+/// Looks up the `RelatedManager` class from the django stubs, returning its `PointLink`.
+fn find_related_manager_link(db: &Database, from_file: &PythonFile) -> Option<PointLink> {
+    let result = import_module_by_strings(
+        db,
+        from_file,
+        ["django", "db", "models", "fields", "related_descriptors"],
+    )?;
+    let ImportResult::File(file_index) = result else {
+        return None;
+    };
+    let file = db.vfs.file(file_index)?;
+    let name_index = file.symbol_table.lookup_symbol("RelatedManager")?;
+    let class_def = NodeRef::new(file, name_index).maybe_name_of_class()?;
+    let link = PointLink::new(file.file_index, class_def.index());
+    // Ensure class infos are computed: downstream operations (mro_without_remap,
+    // incomplete_mro, etc.) call use_cached_class_infos and will panic if skipped.
+    // cache_class_name satisfies the precondition that the NameDef point is set
+    // before ensure_calculated_class_infos is called (mirrors python_state.rs pattern).
+    let name_def_ref = NodeRef::new(file, class_def.name_def().index());
+    cache_class_name(name_def_ref, class_def);
+    ClassInitializer::from_link(db, link).ensure_calculated_class_infos(db);
+    Some(link)
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Instance<'a> {
@@ -533,6 +585,23 @@ impl<'a> Instance<'a> {
                 return LookupDetails {
                     class: TypeOrClass::Class(self.class),
                     lookup: LookupResult::any(AnyCause::Todo),
+                    attr_kind: AttributeKind::Attribute,
+                    mro_index: None,
+                };
+            }
+        }
+        // Add access for Django's related_name reverse relations.
+        // Only check user-defined models (not Django stubs) to avoid triggering uncomputed class infos.
+        if self.class.has_django_stubs_base_class(i_s.db)
+            && !self.class.file.is_from_django(i_s.db)
+        {
+            if let Some(source_link) =
+                self.class.find_django_related_name_source_class(i_s.db, name)
+            {
+                let lookup = build_related_manager_lookup(i_s.db, self.class.file, source_link);
+                return LookupDetails {
+                    class: TypeOrClass::Class(self.class),
+                    lookup,
                     attr_kind: AttributeKind::Attribute,
                     mro_index: None,
                 };

--- a/crates/zuban_python/tests/mypylike/tests/django.test
+++ b/crates/zuban_python/tests/mypylike/tests/django.test
@@ -56,3 +56,43 @@ def f(album: Album):
 __main__.py:25:complete -> [artist, artist_id]
 __main__.py:27:complete -> [composer, composer_id]
 __main__.py:29:complete -> [name]
+
+[case django_related_name]
+from django.db import models
+
+class Author(models.Model):
+    name = models.CharField(max_length=100)
+
+class Book(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='books')
+
+class Magazine(models.Model):
+    editor = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='edited_magazines')
+
+class Newspaper(models.Model):
+    editor = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='+')
+ 
+class WikipediaArticle(models.Model):
+    authors = models.ManyToManyField(Author, through="WikipediaArticleAuthors", related_name="wikipedia_articles")  # E: Need type annotation for "authors"
+
+class WikipediaArticleAuthors(models.Model):
+    article = models.ForeignKey(WikipediaArticle, on_delete=models.CASCADE)
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+def f(author: Author):
+    reveal_type(author.books)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[__main__.Book]"
+    reveal_type(author.book_set)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[__main__.Book]"
+    reveal_type(author.edited_magazines)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[__main__.Magazine]"
+    reveal_type(author.wikipedia_articles)  # N: Revealed type is "django.db.models.fields.related_descriptors.RelatedManager[__main__.WikipediaArticle]"
+    author.nonexistent_related  # E: "Author" has no attribute "nonexistent_related"
+    author.newspaper_set  # E: "Author" has no attribute "newspaper_set"
+
+
+    #? complete
+    author.books
+    #? complete
+    author.edited_magazines
+
+[out]
+__main__.py:32:complete -> [books]
+__main__.py:34:complete -> [edited_magazines]


### PR DESCRIPTION
Love your work on this. One blocker for us to move completely over here is the lack of support for django foreignkey/related_name functionality. I took a stab at this today. Most of this was done by claude while I tested against my extensive python codebase. If you hate this, I understand - I'm no rust expert and I'm sure you could do a much better job on this. The test additions are very useful IMO and reflective of real world django usage. 

Below is my current commit message. It includes new functionality for the above, plus a number of crash fixes for situations I ran into while using the new build with VSCode.


When a model has a ForeignKey with related_name="books", accessing author_instance.books is now recognized as valid, returns RelatedManager[Book], and appears in completions. This also supports the related_name="+" variant where the reverse lookup is disabled. The default reverse lookup of "<model>_set" is also supported. ManyToManyField with related_name is also supported for the reverse accessor. The django.test was updated to verify this new functionality.

Also some panics discovered during testing:

1. is_protocol: changed to use maybe_cached_class_infos so it returns false instead of panicking when a django-stubs class (like RelatedManager) hasn't had its class infos computed yet.

2. delayed_diagnostics assertion in flow_analysis: attribute lookup on RelatedManager[Book] can trigger ensure_calculated_diagnostics_for_class → with_new_empty_and_delay_further from inside with_new_empty_without_unfinished_partial_checking, which previously caused an assertion failure. Inner delayed diagnostics are now propagated to the outer context so they are processed normally.

3. debug_assert in vfs local_fs (directory scan): traversal would panic in debug builds when encountering non-file/non-dir/non-symlink entries (sockets, FIFOs, device files). Replaced with a proper else-if/else that skips such entries silently.

4. debug_assert in vfs local_fs (follow_symlink_internal): same assertion when resolving a symlink that points to a non-file/non-dir target. Replaced with an Err return so the caller's warn+continue path handles it gracefully.

5. debug_assert in vfs local_fs (read_and_watch_entry): same assertion when processing a file-system notification event for a path whose type is neither file, directory, nor symlink. Replaced with an early None return so the entry is silently ignored.

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [ ] I (<Your Name>) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
