### PR TITLE
Build sdist in CI with `maturin-action`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,6 +111,14 @@ jobs:
           key: "swatinem-${{ matrix.t.target }}"
       - name: "Pre-Build"
         run: ./pre-maturin-build.sh
+
+      - name: "Build Source Distribution"
+        uses: PyO3/maturin-action@v1
+        if: ${{ matrix.t.target == 'x86_64-unknown-linux-gnu' }}
+        with:
+          command: sdist
+          args: --out dist
+
       - name: "Build Wheel"
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
- [x] I (Nicholas Bollweg) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.

Changes:
- builds a `.tar.gz` during the `x86_64-unknown-linux-gnu` excursion in `wheels.yml`

References:
- for #444 