### PR TITLE
Add pre-commit/prek hooks that install zuban from PyPI

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,17 @@
+- id: zuban
+  name: zuban
+  description: Type-check Python files with zuban (PyRight-like mode)
+  entry: zuban check
+  language: python
+  types_or: [python, pyi]
+  require_serial: true
+  minimum_pre_commit_version: '2.9.2'
+
+- id: zmypy
+  name: zmypy
+  description: Type-check Python files with zuban in mypy-compatible mode
+  entry: zmypy
+  language: python
+  types_or: [python, pyi]
+  require_serial: true
+  minimum_pre_commit_version: '2.9.2'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,14 @@ insta = "*"
 pre-release-hook = [
     "sed",
     "-i",
+    "-e",
     "s/^version = .*$/version = \"{{version}}\"/",
+    "-e",
+    "s/^    \"zuban==.*\",$/    \"zuban=={{version}}\",/",
     # It seems like this is being run for every Cargo.toml
     "../../deploy/pypi/zuban/pyproject.toml",
+    # Keeps the pre-commit/prek hook shim's pinned zuban version in sync
+    "../../pyproject.toml",
 ]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ bash scripts/install-locally.sh
 
 Note that your build will not properly work if submodules are not cloned.
 
+### Using zuban as a pre-commit / prek hook
+
+Zuban can be used as a [pre-commit](https://pre-commit.com) or
+[prek](https://github.com/j178/prek) hook. Both hook ids install the published
+`zuban` wheel from PyPI, so no Rust toolchain or from-source build is required:
+
+```yaml
+repos:
+  - repo: https://github.com/zubanls/zuban
+    rev: v0.9.0  # a zuban tag; see https://github.com/zubanls/zuban/tags
+    hooks:
+      - id: zuban   # zuban check: PyRight-like mode
+      # - id: zmypy # zuban mypy: mypy-compatible mode
+```
+
+Use `zuban` for PyRight-like checking or `zmypy` for mypy-compatible checking;
+pick whichever mode matches your project's existing configuration.
+
 ## License
 
 This project is dual licensed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "zuban-pre-commit"
 version = "0.9.0"
 description = "Shim so pre-commit/prek can install zuban from PyPI as a hook"
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 dependencies = [
     "zuban==0.9.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zuban-pre-commit"
+version = "0.9.0"
+description = "Shim so pre-commit/prek can install zuban from PyPI as a hook"
+requires-python = ">=3.9"
+dependencies = [
+    "zuban==0.9.0",
+]
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
Expose zuban (PyRight-like check mode) and zmypy (mypy-compatible mode) as pre-commit/prek hooks via .pre-commit-hooks.yaml. Since the workspace root Cargo.toml is a virtual manifest and requires a very new Rust toolchain, building from source per-consumer isn't practical, so both hooks use language: python with a thin pyproject.toml shim that pins and installs the prebuilt zuban wheel from PyPI. The release pre-release hook now keeps that pin in sync automatically.

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [x] I (Christian Ledermann) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
