### PR TITLE
Fix panic when hovering a self attribute of a base class

### DIFF
--- a/crates/zuban_python/src/heuristic_infer.rs
+++ b/crates/zuban_python/src/heuristic_infer.rs
@@ -1255,7 +1255,9 @@ impl<'db, 'state> HeuristicInference<'db, 'state, '_> {
                         )))
                     }
                 }
-            } else if matches!(base_t, Type::Self_) {
+            } else if matches!(base_t, Type::Self_)
+                && directed_to.file.file_index == file.file_index
+            {
                 // TODO this might be the wrong function context
                 out = self.infer_name(new_name)
             } else {

--- a/crates/zuban_python/tests/mypylike/tests/documentation.test
+++ b/crates/zuban_python/tests/mypylike/tests/documentation.test
@@ -1351,3 +1351,27 @@ x: X
 __main__.py:7:documentation -> "```python\n(variable) n: Node\n```"
 __main__.py:10:documentation -> "```python\n(variable) Y: int\n```"
 __main__.py:12:documentation -> "```python\n(type alias) X = list[Any]\n```"
+
+[case docs_self_attribute_of_test_case_base_class]
+from case import TestCase
+
+class MyTest(TestCase):
+    def test_something(self):
+        #? documentation
+        self.assertEqual
+
+# This mimics unittest.TestCase.  The assert methods before assertEqual matter:
+# they push the node index of assertEqual past the number of nodes of
+# __main__.py, so that index is out of bounds for __main__.py.
+[file case.pyi]
+from typing import Any
+
+class TestCase:
+    def assertTrue(self, expr: Any, msg: Any = None) -> None: ...
+    def assertFalse(self, expr: Any, msg: Any = None) -> None: ...
+    def assertIs(self, expr1: object, expr2: object, msg: Any = None) -> None: ...
+    def assertIsNone(self, obj: object, msg: Any = None) -> None: ...
+    def assertEqual(self, first: Any, second: Any, msg: Any = None) -> None: ...
+
+[out]
+__main__.py:6:documentation -> "```python\n(function) def assertEqual(first: Any, second: Any, msg: Any = ...) -> None\n```"


### PR DESCRIPTION
Fixes #544.

The heuristic inference of a `self` attribute continued in the hovered file, but the name of the attribute belongs to the file of the base class.  A node index of that file then indexed the points of the hovered file.  That index is out of bounds for a big base class, and a wrong point for a small one.

The test mimics `unittest.TestCase` with a local stub instead of importing it.  The signatures come from `third_party/typeshed/stdlib/unittest/case.pyi`.  With the real `unittest`, zuban follows the stub to the source of the interpreter for the docstring, so the expected documentation depends on the CPython version.  The methods before `assertEqual` are also the reason the panic happens: they push the node index of `assertEqual` past the number of nodes of `__main__.py`.

Disclosure: An AI coding agent found the cause of the panic and wrote this fix and its test. 

- [x] I (Manuel Vázquez Acosta) own the content in this Pull Request. Neither my employer or anyone else has rights to this content. I here by grant to Dave Halter (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, sell and distribute my contributions and such derivative works.
