### PR TITLE
Override the default stack size on Windows to 16MB

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,15 @@
+# HACK: On Windows only, set the stack size to 16MB. This prevents an overflow from
+# occurring on deep code paths.
+
+# 64 bit MSVC
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+	"-C", "link-arg=/STACK:16000000"
+]
+
+# NOTE: Pretty sure we don't need this, but just in case.
+# 64 bit Mingw
+[target.x86_64-pc-windows-gnu]
+rustflags = [
+    "-C", "link-arg=-Wl,--stack,16000000"
+]


### PR DESCRIPTION
This prevents the stack overflows seen in #540 and #540.

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [x] I (Mauricio A. Rovira Galvez) own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
