### PR TITLE
Scan type ignore comments once per file instead of re-scanning text per issue

### DIFF
--- a/crates/parsa_python_cst/src/code_actions.rs
+++ b/crates/parsa_python_cst/src/code_actions.rs
@@ -1,6 +1,6 @@
 use parsa_python::CodeIndex;
 
-use crate::{Tree, TypeIgnoreComment};
+use crate::{IgnoreDirectives, Tree, TypeIgnoreComment};
 
 pub struct TypeIgnoreInsertion<'tree> {
     pub insertion_index: CodeIndex,
@@ -26,9 +26,10 @@ impl Tree {
     /// Checks where we can insert `type: ignore[<code>]` and `zuban: ignore[<code>]`
     pub fn insertion_point_for_type_ignore(
         &self,
+        directives: &IgnoreDirectives,
         position: CodeIndex,
     ) -> Option<TypeIgnoreInsertion<'_>> {
-        match self.type_ignore_comment_for(position, position) {
+        match directives.type_ignore_comment_for(self.code(), position, position) {
             Some(TypeIgnoreComment::WithCodes {
                 codes,
                 codes_start_at_index,

--- a/crates/parsa_python_cst/src/lib.rs
+++ b/crates/parsa_python_cst/src/lib.rs
@@ -5,6 +5,7 @@ mod match_stmt;
 mod ranges;
 mod signatures;
 mod strings;
+mod type_ignores;
 
 use std::{
     borrow::Cow,
@@ -29,6 +30,7 @@ use parsa_python::{
 pub use ranges::Range;
 pub use signatures::{SignatureArg, SignatureArgsIterator, SignatureBase};
 pub use strings::PythonString;
+pub use type_ignores::{IgnoreDirective, IgnoreDirectives, TypeIgnoreComment, maybe_type_ignore};
 
 pub const NAME_DEF_TO_NAME_DIFFERENCE: u32 = 1;
 
@@ -98,80 +100,13 @@ impl Tree {
         leaf.end()
     }
 
-    pub fn type_ignore_comment_for(
-        &self,
-        start: CodeIndex,
-        end: CodeIndex,
-    ) -> Option<TypeIgnoreComment<'_>> {
-        // Returns Some(None) when there is a type: ignore
-        // Returns Some("foo") when there is a type: ignore['foo']
-        let code = self.code();
-        let relevant_region = if let Some(newline) = code[end as usize..].find(['\n', '\r']) {
-            &code[start as usize..end as usize + newline]
-        } else {
-            &code[start as usize..]
-        };
-        Self::type_ignore_comment_for_region(start, relevant_region)
-    }
-
-    fn type_ignore_comment_for_region(
-        mut start_at: CodeIndex,
-        region: &str,
-    ) -> Option<TypeIgnoreComment<'_>> {
-        let mut result = None;
-        for line in region.split(['\n', '\r']) {
-            let mut iterator = line.split('#');
-            start_at += iterator.next().unwrap().len() as CodeIndex + 1;
-            for comment in iterator {
-                let rest = comment.trim_start_matches(' ');
-                let mut kind = "type";
-                if let Some(ignore) = rest.strip_prefix("type:").or_else(|| {
-                    kind = "zuban";
-                    rest.strip_prefix("zuban:")
-                }) {
-                    let ignore = ignore.trim_start_matches(' ');
-                    let new = maybe_type_ignore(
-                        kind,
-                        start_at + (comment.len() - ignore.len()) as CodeIndex,
-                        ignore,
-                    );
-                    if let Some(new) = new {
-                        if let Some(old) = &mut result {
-                            match (old, new) {
-                                (
-                                    TypeIgnoreComment::WithCodes {
-                                        codes_of_later_type_ignores,
-                                        ..
-                                    },
-                                    TypeIgnoreComment::WithCodes {
-                                        codes: new_codes, ..
-                                    },
-                                ) => codes_of_later_type_ignores.push(new_codes),
-                                (old, _) => *old = TypeIgnoreComment::WithoutCode,
-                            }
-                        } else {
-                            result = Some(new);
-                        }
-                    }
-                }
-                start_at += comment.len() as CodeIndex + 1;
-            }
-            start_at += 1;
-        }
-        result
-    }
-
-    pub fn has_type_ignore_at_start(&self) -> Result<bool, &str> {
-        match Self::type_ignore_comment_for_region(0, self.before_first_statement()) {
+    pub fn has_type_ignore_at_start(&self, directives: &IgnoreDirectives) -> Result<bool, &str> {
+        let before_first_statement_end = self.0.root_node().nth_child(0).start();
+        match directives.fold_in_range(self.code(), 0, before_first_statement_end) {
             Some(TypeIgnoreComment::WithCodes { codes: code, .. }) => Err(code),
             Some(TypeIgnoreComment::WithoutCode) => Ok(true),
             None => Ok(false),
         }
-    }
-
-    fn before_first_statement(&self) -> &str {
-        let start = self.0.root_node().nth_child(0).start();
-        &self.code()[0..start as usize]
     }
 
     pub fn mypy_inline_config_directives(&self) -> impl Iterator<Item = (CodeIndex, &str)> {
@@ -460,48 +395,9 @@ impl Tree {
     }
 }
 
-#[derive(Debug)]
-pub enum TypeIgnoreComment<'db> {
-    WithCodes {
-        codes: &'db str,
-        kind: &'static str,
-        codes_start_at_index: CodeIndex,
-        codes_of_later_type_ignores: Vec<&'db str>,
-    },
-    WithoutCode,
-}
-
 pub enum PotentialInlayHint<'db> {
     FunctionDef(FunctionDef<'db>),
     Assignment(Assignment<'db>),
-}
-
-pub fn maybe_type_ignore<'db>(
-    kind: &'static str,
-    start_at: CodeIndex,
-    text: &'db str,
-) -> Option<TypeIgnoreComment<'db>> {
-    if let Some(after) = text.strip_prefix("ignore") {
-        let trimmed = after.trim_start_matches(' ');
-        let start_at = start_at + (text.len() - trimmed.len()) as CodeIndex;
-        let trimmed = trimmed.trim_end_matches(' ');
-        if let Some(trimmed) = trimmed.strip_prefix('[')
-            && let Some(trimmed) = trimmed.strip_suffix(']')
-            && !trimmed.is_empty()
-        {
-            return Some(TypeIgnoreComment::WithCodes {
-                kind,
-                codes: trimmed,
-                codes_start_at_index: start_at + 1,
-                codes_of_later_type_ignores: vec![],
-            });
-        }
-
-        if after.is_empty() || after.starts_with([' ', '\t']) {
-            return Some(TypeIgnoreComment::WithoutCode);
-        }
-    }
-    None
 }
 
 pub trait InterestingNodeSearcher<'db> {

--- a/crates/parsa_python_cst/src/type_ignores.rs
+++ b/crates/parsa_python_cst/src/type_ignores.rs
@@ -1,0 +1,327 @@
+use parsa_python::CodeIndex;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TypeIgnoreComment<'db> {
+    WithCodes {
+        codes: &'db str,
+        kind: &'static str,
+        codes_start_at_index: CodeIndex,
+        codes_of_later_type_ignores: Vec<&'db str>,
+    },
+    WithoutCode,
+}
+
+/// All `# type: ignore` / `# zuban: ignore` comments of a file, scanned once and ordered by
+/// position.
+#[derive(Debug, Clone, Default)]
+pub struct IgnoreDirectives {
+    entries: Vec<IgnoreDirective>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgnoreDirective {
+    /// The offset of the `#` that starts the comment containing this directive
+    pub hash_start: CodeIndex,
+    /// "type" or "zuban"
+    pub kind: &'static str,
+    /// The span of the raw text within the brackets of e.g. `# type: ignore[a, b]`.
+    /// `None` for a bare ignore like `# type: ignore`.
+    pub codes_span: Option<(CodeIndex, CodeIndex)>,
+}
+
+impl IgnoreDirectives {
+    pub fn scan(code: &str) -> Self {
+        let mut entries = vec![];
+        let mut line_start: CodeIndex = 0;
+        for line in code.split(['\n', '\r']) {
+            let mut iterator = line.split('#');
+            // The first part precedes any `#` and can therefore not contain a comment
+            let mut comment_start = line_start + iterator.next().unwrap().len() as CodeIndex + 1;
+            for comment in iterator {
+                if let Some(directive) = maybe_ignore_directive_in_comment(comment, comment_start) {
+                    entries.push(directive);
+                }
+                comment_start += comment.len() as CodeIndex + 1;
+            }
+            line_start += line.len() as CodeIndex + 1;
+        }
+        Self { entries }
+    }
+
+    pub fn entries(&self) -> &[IgnoreDirective] {
+        &self.entries
+    }
+
+    /// Returns the merged ignore comment relevant for an issue with the given span, i.e. all
+    /// ignore comments between `start` and the end of the line that contains `end`.
+    pub fn type_ignore_comment_for<'code>(
+        &self,
+        code: &'code str,
+        start: CodeIndex,
+        end: CodeIndex,
+    ) -> Option<TypeIgnoreComment<'code>> {
+        // Returns Some(WithoutCode) when there is a type: ignore
+        // Returns Some(WithCodes{codes: "foo", ..}) when there is a type: ignore[foo]
+        let end_of_last_line = match code[end as usize..].find(['\n', '\r']) {
+            Some(newline) => end + newline as CodeIndex,
+            None => code.len() as CodeIndex,
+        };
+        self.fold_in_range(code, start, end_of_last_line)
+    }
+
+    /// Merges all directives whose comments start within `start..end`, with the same semantics
+    /// the previous per-issue text scan had: multiple coded ignores accumulate their codes, while
+    /// any bare ignore makes the result a bare ignore.
+    pub(crate) fn fold_in_range<'code>(
+        &self,
+        code: &'code str,
+        start: CodeIndex,
+        end: CodeIndex,
+    ) -> Option<TypeIgnoreComment<'code>> {
+        let first_index = self
+            .entries
+            .partition_point(|entry| entry.hash_start < start);
+        let mut result = None;
+        for entry in &self.entries[first_index..] {
+            if entry.hash_start >= end {
+                break;
+            }
+            let new = entry.as_type_ignore_comment(code);
+            if let Some(old) = &mut result {
+                match (old, new) {
+                    (
+                        TypeIgnoreComment::WithCodes {
+                            codes_of_later_type_ignores,
+                            ..
+                        },
+                        TypeIgnoreComment::WithCodes {
+                            codes: new_codes, ..
+                        },
+                    ) => codes_of_later_type_ignores.push(new_codes),
+                    (old, _) => *old = TypeIgnoreComment::WithoutCode,
+                }
+            } else {
+                result = Some(new);
+            }
+        }
+        result
+    }
+}
+
+impl IgnoreDirective {
+    pub fn is_bare(&self) -> bool {
+        self.codes_span.is_none()
+    }
+
+    pub fn codes<'code>(&self, code: &'code str) -> Option<&'code str> {
+        self.codes_span
+            .map(|(start, end)| &code[start as usize..end as usize])
+    }
+
+    fn as_type_ignore_comment<'code>(&self, code: &'code str) -> TypeIgnoreComment<'code> {
+        match self.codes_span {
+            Some((start, _)) => TypeIgnoreComment::WithCodes {
+                codes: self.codes(code).unwrap(),
+                kind: self.kind,
+                codes_start_at_index: start,
+                codes_of_later_type_ignores: vec![],
+            },
+            None => TypeIgnoreComment::WithoutCode,
+        }
+    }
+}
+
+fn maybe_ignore_directive_in_comment(
+    comment: &str,
+    comment_start: CodeIndex,
+) -> Option<IgnoreDirective> {
+    let rest = comment.trim_start_matches(' ');
+    let mut kind = "type";
+    let ignore = rest.strip_prefix("type:").or_else(|| {
+        kind = "zuban";
+        rest.strip_prefix("zuban:")
+    })?;
+    let ignore = ignore.trim_start_matches(' ');
+    let type_ignore = maybe_type_ignore(
+        kind,
+        comment_start + (comment.len() - ignore.len()) as CodeIndex,
+        ignore,
+    )?;
+    Some(IgnoreDirective {
+        hash_start: comment_start - 1,
+        kind,
+        codes_span: match type_ignore {
+            TypeIgnoreComment::WithCodes {
+                codes,
+                codes_start_at_index,
+                ..
+            } => Some((
+                codes_start_at_index,
+                codes_start_at_index + codes.len() as CodeIndex,
+            )),
+            TypeIgnoreComment::WithoutCode => None,
+        },
+    })
+}
+
+pub fn maybe_type_ignore<'db>(
+    kind: &'static str,
+    start_at: CodeIndex,
+    text: &'db str,
+) -> Option<TypeIgnoreComment<'db>> {
+    if let Some(after) = text.strip_prefix("ignore") {
+        let trimmed = after.trim_start_matches(' ');
+        let start_at = start_at + (text.len() - trimmed.len()) as CodeIndex;
+        let trimmed = trimmed.trim_end_matches(' ');
+        if let Some(trimmed) = trimmed.strip_prefix('[')
+            && let Some(trimmed) = trimmed.strip_suffix(']')
+            && !trimmed.is_empty()
+        {
+            return Some(TypeIgnoreComment::WithCodes {
+                kind,
+                codes: trimmed,
+                codes_start_at_index: start_at + 1,
+                codes_of_later_type_ignores: vec![],
+            });
+        }
+
+        if after.is_empty() || after.starts_with([' ', '\t']) {
+            return Some(TypeIgnoreComment::WithoutCode);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spans(code: &str) -> Vec<(CodeIndex, &'static str, Option<&str>)> {
+        IgnoreDirectives::scan(code)
+            .entries()
+            .iter()
+            .map(|entry| (entry.hash_start, entry.kind, entry.codes(code)))
+            .collect()
+    }
+
+    #[test]
+    fn scan_bare_and_coded() {
+        assert_eq!(spans("x = 1  # type: ignore\n"), [(7, "type", None)]);
+        assert_eq!(
+            spans("x = 1  # type: ignore[assignment]\n"),
+            [(7, "type", Some("assignment"))]
+        );
+        // Multiple codes with weird spacing keep the raw bracket interior
+        assert_eq!(
+            spans("x = 1  # type: ignore   [ a , b ]\n"),
+            [(7, "type", Some(" a , b "))]
+        );
+        // Tolerates missing trailing newline
+        assert_eq!(spans("x = 1  # type: ignore"), [(7, "type", None)]);
+    }
+
+    #[test]
+    fn scan_non_matches() {
+        assert_eq!(spans("x = 1  # type: ignored\n"), []);
+        assert_eq!(spans("x = 1  # type: ignore_foo\n"), []);
+        assert_eq!(spans("x = 1  # type: ignore[]\n"), []);
+        assert_eq!(spans("x = 1  # type: ignore[a] trailing\n"), []);
+        assert_eq!(spans("x = 1  # types: ignore\n"), []);
+        // `ignore` directly followed by a comment end or whitespace is fine though
+        assert_eq!(spans("x = 1  # type: ignore more\n"), [(7, "type", None)]);
+    }
+
+    #[test]
+    fn scan_kinds_and_multiple_comments_per_line() {
+        assert_eq!(
+            spans("x = 1  # zuban: ignore[foo]\n"),
+            [(7, "zuban", Some("foo"))]
+        );
+        // Note that the conventional way to ignore multiple error codes is the comma syntax
+        // (`# type: ignore[a, b]`, a single directive). Multiple ignore comments on one line are
+        // nevertheless scanned as separate directives, whose codes accumulate on lookup.
+        // A second comment on the same line is scanned separately
+        assert_eq!(
+            spans("x = 1  # a comment # type: ignore[a]\n"),
+            [(19, "type", Some("a"))]
+        );
+        assert_eq!(
+            spans("x = 1  # type: ignore[a] # zuban: ignore[b]\n"),
+            [(7, "type", Some("a")), (25, "zuban", Some("b"))]
+        );
+        assert_eq!(
+            spans("x = 1  # type: ignore[a] # type: ignore\n"),
+            [(7, "type", Some("a")), (25, "type", None)]
+        );
+    }
+
+    #[test]
+    fn scan_offsets_across_lines() {
+        let code = "x = 1\ny = 2  # type: ignore[a]\nz = 3\na = 4  # zuban: ignore\n";
+        assert_eq!(spans(code), [(13, "type", Some("a")), (44, "zuban", None)]);
+        // Windows line endings
+        let code = "x = 1\r\ny = 2  # type: ignore[a]\r\n";
+        assert_eq!(spans(code), [(14, "type", Some("a"))]);
+    }
+
+    #[test]
+    fn lookup_same_line() {
+        let code = "x = 1  # type: ignore[a]\ny = 2\n";
+        let directives = IgnoreDirectives::scan(code);
+        let expected = || {
+            Some(TypeIgnoreComment::WithCodes {
+                codes: "a",
+                kind: "type",
+                codes_start_at_index: 22,
+                codes_of_later_type_ignores: vec![],
+            })
+        };
+        assert_eq!(directives.type_ignore_comment_for(code, 0, 5), expected());
+        // Lookups never look at previous lines
+        assert_eq!(directives.type_ignore_comment_for(code, 26, 31), None);
+        // Comments before the start of the lookup are not considered
+        assert_eq!(directives.type_ignore_comment_for(code, 8, 8), None);
+    }
+
+    #[test]
+    fn lookup_over_multiple_lines() {
+        let code =
+            "foo(  # type: ignore[a]\n    1,  # type: ignore[b]\n    2,\n)  # type: ignore\n";
+        let directives = IgnoreDirectives::scan(code);
+        // A lookup that only spans the first line
+        assert_eq!(
+            directives.type_ignore_comment_for(code, 0, 3),
+            Some(TypeIgnoreComment::WithCodes {
+                codes: "a",
+                kind: "type",
+                codes_start_at_index: 21,
+                codes_of_later_type_ignores: vec![],
+            })
+        );
+        // A lookup over the first two lines merges the coded ignores
+        assert_eq!(
+            directives.type_ignore_comment_for(code, 0, 28),
+            Some(TypeIgnoreComment::WithCodes {
+                codes: "a",
+                kind: "type",
+                codes_start_at_index: 21,
+                codes_of_later_type_ignores: vec!["b"],
+            })
+        );
+        // A lookup over all lines includes the bare ignore, which wins
+        assert_eq!(
+            directives.type_ignore_comment_for(code, 0, 59),
+            Some(TypeIgnoreComment::WithoutCode)
+        );
+    }
+
+    #[test]
+    fn lookup_bare_ignore_wins_in_both_directions() {
+        let code = "foo(  # type: ignore\n    1,  # type: ignore[b]\n)\n";
+        let directives = IgnoreDirectives::scan(code);
+        assert_eq!(
+            directives.type_ignore_comment_for(code, 0, 26),
+            Some(TypeIgnoreComment::WithoutCode)
+        );
+    }
+}

--- a/crates/parsa_python_cst/src/type_ignores.rs
+++ b/crates/parsa_python_cst/src/type_ignores.rs
@@ -11,8 +11,8 @@ pub enum TypeIgnoreComment<'db> {
     WithoutCode,
 }
 
-/// All `# type: ignore` / `# zuban: ignore` comments of a file, scanned once and ordered by
-/// position.
+/// The `# type: ignore` / `# zuban: ignore` comments of a file (at most one per kind and line,
+/// like in Mypy), scanned once and ordered by position.
 #[derive(Debug, Clone, Default)]
 pub struct IgnoreDirectives {
     entries: Vec<IgnoreDirective>,
@@ -37,9 +37,23 @@ impl IgnoreDirectives {
             let mut iterator = line.split('#');
             // The first part precedes any `#` and can therefore not contain a comment
             let mut comment_start = line_start + iterator.next().unwrap().len() as CodeIndex + 1;
+            let mut seen_type = false;
+            let mut seen_zuban = false;
             for comment in iterator {
                 if let Some(directive) = maybe_ignore_directive_in_comment(comment, comment_start) {
-                    entries.push(directive);
+                    // Like Mypy, only honor the leftmost `type: ignore` comment on a line and
+                    // treat later ones as prose. The same holds for `zuban: ignore` comments,
+                    // but one comment of each kind can be combined on a line (see GH #331).
+                    // Unlike Mypy we still scan later `#` segments when earlier ones are no
+                    // ignore comments, because a `#` might e.g. appear within a string, which
+                    // this text-based scan cannot rule out.
+                    let seen = match directive.kind {
+                        "zuban" => &mut seen_zuban,
+                        _ => &mut seen_type,
+                    };
+                    if !std::mem::replace(seen, true) {
+                        entries.push(directive);
+                    }
                 }
                 comment_start += comment.len() as CodeIndex + 1;
             }
@@ -69,9 +83,9 @@ impl IgnoreDirectives {
         self.fold_in_range(code, start, end_of_last_line)
     }
 
-    /// Merges all directives whose comments start within `start..end`, with the same semantics
-    /// the previous per-issue text scan had: multiple coded ignores accumulate their codes, while
-    /// any bare ignore makes the result a bare ignore.
+    /// Merges all directives whose comments start within `start..end`: coded ignores (on
+    /// multiple lines) accumulate their codes, while any bare ignore makes the result a bare
+    /// ignore.
     pub(crate) fn fold_in_range<'code>(
         &self,
         code: &'code str,
@@ -232,26 +246,34 @@ mod tests {
     }
 
     #[test]
-    fn scan_kinds_and_multiple_comments_per_line() {
+    fn scan_kinds_and_leftmost_ignore_comment_wins() {
         assert_eq!(
             spans("x = 1  # zuban: ignore[foo]\n"),
             [(7, "zuban", Some("foo"))]
         );
-        // Note that the conventional way to ignore multiple error codes is the comma syntax
-        // (`# type: ignore[a, b]`, a single directive). Multiple ignore comments on one line are
-        // nevertheless scanned as separate directives, whose codes accumulate on lookup.
-        // A second comment on the same line is scanned separately
+        // An ignore comment after a non-ignore comment is still found, since the first `#`
+        // might e.g. be part of a string
         assert_eq!(
             spans("x = 1  # a comment # type: ignore[a]\n"),
             [(19, "type", Some("a"))]
         );
         assert_eq!(
-            spans("x = 1  # type: ignore[a] # zuban: ignore[b]\n"),
-            [(7, "type", Some("a")), (25, "zuban", Some("b"))]
+            spans("url = 'http://x#y'  # type: ignore[a]\n"),
+            [(20, "type", Some("a"))]
         );
+        // Like in Mypy, only the leftmost ignore comment of a kind on a line is honored
         assert_eq!(
             spans("x = 1  # type: ignore[a] # type: ignore\n"),
-            [(7, "type", Some("a")), (25, "type", None)]
+            [(7, "type", Some("a"))]
+        );
+        assert_eq!(
+            spans("x = 1  # type: ignore # type: ignore[a]\n"),
+            [(7, "type", None)]
+        );
+        // However one comment of each kind can be combined on a line (see GH #331)
+        assert_eq!(
+            spans("x = 1  # type: ignore[a] # zuban: ignore[b]\n"),
+            [(7, "type", Some("a")), (25, "zuban", Some("b"))]
         );
     }
 

--- a/crates/zuban_python/src/code_actions.rs
+++ b/crates/zuban_python/src/code_actions.rs
@@ -60,7 +60,9 @@ impl<'project> Document<'project> {
             let issue_end = diag.end_position().byte_position as CodeIndex;
             if !diag.is_note()
                 && intersects(&check_range, &(issue_start..issue_end))
-                && let Some(insertion) = file.tree.insertion_point_for_type_ignore(issue_start)
+                && let Some(insertion) = file
+                    .tree
+                    .insertion_point_for_type_ignore(&file.ignore_directives, issue_start)
             {
                 let error_code = diag.mypy_error_code();
                 if error_code == "syntax" {

--- a/crates/zuban_python/src/file/diagnostics.rs
+++ b/crates/zuban_python/src/file/diagnostics.rs
@@ -3057,7 +3057,8 @@ pub(super) fn check_override(
                                 if let Some(func) = maybe_func()
                                     && let node = func.node()
                                     && let type_ignore_comment =
-                                        from.file.tree.type_ignore_comment_for(
+                                        from.file.ignore_directives.type_ignore_comment_for(
+                                            from.file.tree.code(),
                                             node.start(),
                                             node.end_position_of_colon(),
                                         )

--- a/crates/zuban_python/src/file/name_binder.rs
+++ b/crates/zuban_python/src/file/name_binder.rs
@@ -70,6 +70,7 @@ pub(crate) struct DbInfos<'db> {
     pub settings: &'db Settings,
     pub flags: &'db FinalizedTypeCheckerFlags,
     pub tree: &'db Tree,
+    pub ignore_directives: &'db IgnoreDirectives,
     pub points: &'db Points,
     pub complex_points: &'db ComplexValues,
     pub issues: &'db Diagnostics,
@@ -254,10 +255,11 @@ impl<'db> NameBinder<'db> {
             return;
         }
         let issue = Issue::from_node_index(self.db_infos.tree, node_index, kind, true);
-        let maybe_ignored = self
-            .db_infos
-            .tree
-            .type_ignore_comment_for(issue.start_position, issue.end_position);
+        let maybe_ignored = self.db_infos.ignore_directives.type_ignore_comment_for(
+            self.db_infos.tree.code(),
+            issue.start_position,
+            issue.end_position,
+        );
         match self
             .db_infos
             .issues

--- a/crates/zuban_python/src/file/python_file.rs
+++ b/crates/zuban_python/src/file/python_file.rs
@@ -108,6 +108,7 @@ pub(crate) enum DunderAllState {
 
 pub(crate) struct PythonFile {
     pub tree: Tree, // TODO should probably not be public
+    pub ignore_directives: IgnoreDirectives,
     pub symbol_table: SymbolTable,
     maybe_dunder_all: OnceLock<Option<DunderAllState>>, // For __all__
     pub points: Points,
@@ -163,6 +164,7 @@ impl Clone for PythonFile {
     fn clone(&self) -> Self {
         Self {
             tree: self.tree.clone(),
+            ignore_directives: self.ignore_directives.clone(),
             symbol_table: self.symbol_table.clone(),
             maybe_dunder_all: self.maybe_dunder_all.clone(),
             points: self.points.clone(),
@@ -308,8 +310,9 @@ impl<'db> PythonFile {
     ) -> Self {
         let is_stub = file_entry.name.ends_with(".pyi");
         let issues = Diagnostics::default();
+        let ignore_directives = IgnoreDirectives::scan(tree.code());
         let mut ignore_type_errors = tree
-            .has_type_ignore_at_start()
+            .has_type_ignore_at_start(&ignore_directives)
             .map(|has_ignore| has_ignore.then_some(IgnoreFileReason::TypeIgnoreAtTopOfFile))
             .unwrap_or_else(|ignore_code| {
                 issues.add(Issue::from_start_stop(
@@ -344,6 +347,7 @@ impl<'db> PythonFile {
         Self::new_internal(
             file_index,
             tree,
+            ignore_directives,
             points,
             issues,
             is_stub,
@@ -356,6 +360,7 @@ impl<'db> PythonFile {
     fn new_internal(
         file_index: FileIndex,
         tree: Tree,
+        ignore_directives: IgnoreDirectives,
         points: Points,
         issues: Diagnostics,
         is_stub: bool,
@@ -373,6 +378,7 @@ impl<'db> PythonFile {
                 settings: &project.settings,
                 flags: flags.as_ref().unwrap_or(&project.flags),
                 tree: &tree,
+                ignore_directives: &ignore_directives,
                 points: &points,
                 complex_points: &complex_points,
                 issues: &issues,
@@ -385,6 +391,7 @@ impl<'db> PythonFile {
         );
         Self {
             tree,
+            ignore_directives,
             file_index,
             symbol_table,
             maybe_dunder_all: OnceLock::default(),
@@ -504,11 +511,13 @@ impl<'db> PythonFile {
             code = Cow::Owned(code.replace('\n', " "));
         }
         let tree = Tree::parse(code.into_owned().into_boxed_str());
+        let ignore_directives = IgnoreDirectives::scan(tree.code());
         let points = Points::new(tree.length());
         let f = db.load_sub_file(self, |file_index| {
             let mut file = PythonFile::new_internal(
                 file_index,
                 tree,
+                ignore_directives,
                 points,
                 Diagnostics::default(),
                 self.is_stub(),
@@ -825,9 +834,11 @@ impl<'db> PythonFile {
             ),
             _ => (self, 0),
         };
-        let maybe_ignored = file
-            .tree
-            .type_ignore_comment_for(issue.start_position + add, issue.end_position + add);
+        let maybe_ignored = file.ignore_directives.type_ignore_comment_for(
+            file.tree.code(),
+            issue.start_position + add,
+            issue.end_position + add,
+        );
         let config = DiagnosticConfig {
             show_column_numbers: true,
             ..Default::default()

--- a/crates/zuban_python/tests/mypylike/tests/basic.test
+++ b/crates/zuban_python/tests/mypylike/tests/basic.test
@@ -1730,6 +1730,43 @@ open([])  # zuban: ignore[call-overload]
 __main__:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
 __main__:4: note: Error code "assignment" not covered by "type: ignore[asdf]" comment
 
+[case type_ignore_on_non_first_line_of_multiline_issue]
+def f(x: int) -> None: ...
+# Issues on single tokens only respect ignores on the line of that token
+f(
+    "a"  # type: ignore[arg-type]
+)
+f(
+    "b"  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+)  # type: ignore[arg-type]
+# Issues that span multiple lines respect an ignore on any of their lines
+open(
+    []  # type: ignore[call-overload]
+)
+open(
+    []
+)  # type: ignore[call-overload]
+
+[case multiple_error_codes_in_type_ignore]
+# The conventional syntax for ignoring multiple error codes on one line
+a: int = ""  # type: ignore[foo, assignment]
+b: int = ""  # type: ignore[assignment,foo]
+# The note about non-covered error codes quotes the full bracket content
+c: int = ""  # type: ignore[foo, bar] # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
+             # N: Error code "assignment" not covered by "type: ignore[foo, bar]" comment
+
+[case multiple_type_ignore_comments_on_one_line]
+# Unconventional (the comma syntax above is preferred and is what Mypy
+# supports), but Zuban has always accumulated the codes of multiple ignore
+# comments on one line; this pins that behavior.
+a: int = ""  # type: ignore[foo] # type: ignore[assignment]
+# The note about non-covered error codes quotes the first ignore comment
+b: int = ""  # type: ignore[foo] # type: ignore[bar] # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
+             # N: Error code "assignment" not covered by "type: ignore[foo]" comment
+# A bare ignore combined with a coded one ignores everything
+c: int = ""  # type: ignore[foo] # type: ignore
+d: int = ""  # type: ignore # type: ignore[foo]
+
 [case try_except_attribute_error_non_lookups_allowed]
 # flags: --check-untyped-defs
 def union() -> int | str: ...

--- a/crates/zuban_python/tests/mypylike/tests/basic.test
+++ b/crates/zuban_python/tests/mypylike/tests/basic.test
@@ -1756,16 +1756,21 @@ c: int = ""  # type: ignore[foo, bar] # E: Incompatible types in assignment (exp
              # N: Error code "assignment" not covered by "type: ignore[foo, bar]" comment
 
 [case multiple_type_ignore_comments_on_one_line]
-# Unconventional (the comma syntax above is preferred and is what Mypy
-# supports), but Zuban has always accumulated the codes of multiple ignore
-# comments on one line; this pins that behavior.
-a: int = ""  # type: ignore[foo] # type: ignore[assignment]
-# The note about non-covered error codes quotes the first ignore comment
-b: int = ""  # type: ignore[foo] # type: ignore[bar] # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
+# Multiple ignore comments of the same kind on one line are not really defined
+# (use the comma syntax instead). Like in Mypy, the leftmost one wins and the
+# rest is treated as prose.
+a: int = ""  # type: ignore[assignment] # type: ignore[foo]
+b: int = ""  # type: ignore # type: ignore[foo]
+c: int = ""  # type: ignore[foo] # type: ignore[assignment] # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
              # N: Error code "assignment" not covered by "type: ignore[foo]" comment
-# A bare ignore combined with a coded one ignores everything
-c: int = ""  # type: ignore[foo] # type: ignore
-d: int = ""  # type: ignore # type: ignore[foo]
+d: int = ""  # type: ignore[foo] # type: ignore # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
+             # N: Error code "assignment" not covered by "type: ignore[foo]" comment
+# One "type: ignore" and one "zuban: ignore" can be combined though, see the
+# case type_ignore_multiple_ignores (GH #331)
+e: int = ""  # type: ignore[foo] # zuban: ignore[assignment]
+# Unlike in Mypy, an ignore comment after a non-ignore comment still counts,
+# also because a `#` may appear within a string on the same line
+f: int = ""  # some comment # type: ignore[assignment]
 
 [case try_except_attribute_error_non_lookups_allowed]
 # flags: --check-untyped-defs


### PR DESCRIPTION
Introduces IgnoreDirectives, a per-file registry of all `# type: ignore` / `# zuban: ignore` comments, scanned once at file creation and stored on PythonFile. Per-issue lookups now consult the registry (binary search by comment offset) instead of re-scanning the raw source text for every emitted issue.

The lookup reproduces the previous per-region text-scan semantics exactly: comments participate from the issue's start offset through the end of the line containing the issue's end, multiple coded ignores accumulate their codes and any bare ignore collapses the result to a bare ignore.

This is groundwork for unused-ignore checks (`--warn-unused-ignores`), which need an enumerable registry of ignore comments plus attribution of which comment suppressed an issue. No behavior change intended.

<!--
Zuban is licensed under the AGPL. To allow Zuban to be re-licensed
commercially, contributors must grant full rights to their contributions.
-->

- [x] I Seamus O Ceanainn own the content in this Pull Request. Neither my employer
  or anyone else has rights to this content. I here by grant to Dave Halter
  (the owner of Zuban) a perpetual, worldwide, non-exclusive, no-charge,
  royalty-free, irrevocable copyright license to reproduce, prepare derivative
  works of, publicly display, publicly perform, sublicense, sell and distribute
  my contributions and such derivative works.
